### PR TITLE
docs: add Cloud Integration - Roles & Permissions (AWS, Azure, GCP)

### DIFF
--- a/docs/AWSPermissions.md
+++ b/docs/AWSPermissions.md
@@ -1,0 +1,224 @@
+# AWS Permissions
+
+CloudPi connects to AWS through an **IAM role** (assumed with an External ID) or,
+optionally, an IAM user with access keys. This page lists the permissions CloudPi
+needs, grouped by the onboarding feature they power.
+
+Grant only the permissions for the features you enable during onboarding:
+
+| Feature | Permissions | Access type |
+|---------|-------------|-------------|
+| **Billing-only** | Billing / Cost | Read-only |
+| **Recommendations** | Inventory + Metrics | Read-only |
+| **Automation** | Remediation groups | Write |
+
+- **Read-Only role** = Billing-only + Recommendations (collection only).
+- **Write / Remediation role** = the read-only permissions plus **Automation**, the
+  exact actions CloudPi performs when it runs an approved optimization workflow.
+
+!!! note "Prerequisites"
+    - Run in the target account (the organization **management account** if you want org-wide discovery).
+    - Terraform >= 1.0 and an identity allowed to create IAM roles, users, and policies.
+
+!!! tip "Setup"
+    ```bash
+    cp terraform.tfvars.example terraform.tfvars
+    # set trusted_account_id (CloudPi account), external_id (recommended),
+    # and cur_bucket_arns (restrict CUR access to your export bucket)
+    terraform init
+    terraform apply
+    terraform output -raw role_arn        # give this + external_id to CloudPi
+    ```
+
+---
+
+## Read-Only role (Billing-only + Recommendations)
+
+Everything below is **read-only**. Grant the groups for the features you enable.
+
+### Billing / Cost — *Billing-only feature*
+
+Required for cost data and forecast.
+
+| Permission | Used for |
+|------------|----------|
+| `s3:ListBucket`, `s3:GetObject` (on the CUR/FOCUS bucket) | Reading your **actual cost/usage** — CUR 2.0 / FOCUS 1.0 Parquet ingestion |
+| `ce:GetCostForecast` | Monthly cost **forecast** (falls back to a built-in calculator if denied) |
+| `pricing:GetProducts` | Rate cards for savings estimates |
+
+### Inventory — *Recommendations feature*
+
+Required to list resources for rightsizing.
+
+| Permission | Covers these services |
+|------------|-----------------------|
+| `ec2:Describe*` | EC2, AMI, EBS, Snapshot, ENI, Elastic IP, VPC, VPC Endpoint, NAT Gateway, Transit Gateway (+attachment), VPN |
+| `rds:Describe*` | RDS, Aurora |
+| `lambda:List*` | Lambda functions and their tags |
+| `tag:GetResources`, `resourcegroupstaggingapi:GetResources` | Tags for every resource above |
+
+### Metrics — *Recommendations feature*
+
+Required for utilization-based recommendations.
+
+| Permission | Used for |
+|------------|----------|
+| `cloudwatch:ListMetrics`, `cloudwatch:GetMetricData`, `cloudwatch:GetMetricStatistics` | CPU / network / disk utilization from CloudWatch |
+| `logs:Describe*` | Log-group metadata |
+
+Namespaces collected: `AWS/EC2`, `EBS`, `RDS`, `Lambda`, `NATGateway`, `TransitGateway`, `VPN`.
+
+### Org / Account discovery *(optional)*
+
+`organizations:List*` lets CloudPi auto-discover the member accounts in your
+organization. Needed **only in the management account** — skip this block for a
+single account.
+
+---
+
+## Write / Remediation role (Automation)
+
+The Write role is the Read-Only role above **plus** the remediation actions below,
+which power the **Automation** feature. CloudPi calls these **only after a
+recommendation is approved** through your workflow rules. Grant only the groups
+whose remediations you intend to enable.
+
+### Remediation groups
+
+=== "Compute (EC2 / EBS / AMI / EIP)"
+
+    Start, stop, and terminate instances; resize and right-size; capture snapshots
+    and AMIs; delete idle volumes and snapshots; release unused Elastic IPs; maintain tags.
+
+    `ec2:StartInstances`, `ec2:StopInstances`, `ec2:TerminateInstances`,
+    `ec2:ModifyInstanceAttribute`, `ec2:CreateImage`, `ec2:DeregisterImage`,
+    `ec2:CreateSnapshot`, `ec2:DeleteSnapshot`, `ec2:ModifyVolume`,
+    `ec2:DeleteVolume`, `ec2:AssociateAddress`, `ec2:ReleaseAddress`,
+    `ec2:CreateTags`, `ec2:DeleteTags`
+
+=== "Network cleanup (VPC family)"
+
+    Tear down idle or orphaned ENIs, NAT gateways, endpoints, flow logs, subnets,
+    route tables, NACLs, security groups, VPCs, Transit Gateway attachments, and VPN connections.
+
+    `ec2:DeleteNetworkInterface`, `ec2:DeleteNatGateway`, `ec2:DeleteVpcEndpoints`,
+    `ec2:DeleteFlowLogs`, `ec2:DetachInternetGateway`, `ec2:DeleteInternetGateway`,
+    `ec2:DeleteSubnet`, `ec2:DeleteRouteTable`, `ec2:DeleteNetworkAcl`,
+    `ec2:DeleteSecurityGroup`, `ec2:DeleteVpc`, `ec2:DeleteTransitGatewayVpcAttachment`,
+    `ec2:DeleteTransitGatewayPeeringAttachment`, `ec2:DeleteTransitGatewayConnect`,
+    `ec2:DeleteVpnConnection`, `ec2:DeleteClientVpnEndpoint`
+
+=== "Database (RDS / Aurora)"
+
+    Modify DB instance and cluster settings, right-size, manage RDS Proxy (with its
+    credentials secret), and maintain tags.
+
+    `rds:ModifyDBInstance`, `rds:ModifyDBCluster`, `rds:AddTagsToResource`,
+    `rds:RemoveTagsFromResource`, `rds:CreateDBProxy`, `rds:RegisterDBProxyTargets`,
+    `secretsmanager:CreateSecret`, `secretsmanager:ListSecrets`
+
+=== "Serverless / CDN / data stores"
+
+    Reconfigure and right-size Lambda, DynamoDB, and DAX; front content with
+    CloudFront; manage auto-scaling and tags.
+
+    `lambda:UpdateFunctionConfiguration`, `lambda:DeleteFunction`, `lambda:TagResource`,
+    `cloudfront:CreateDistribution`, `redshift:CreateTags`, `redshift:DeleteTags`,
+    `dynamodb:TagResource`, `dynamodb:UntagResource`, `dynamodb:UpdateTimeToLive`,
+    `dynamodb:UpdateContinuousBackups`, `dynamodb:CreateBackup`, `dynamodb:DeleteTable`,
+    `dax:CreateCluster`, `application-autoscaling:RegisterScalableTarget`,
+    `application-autoscaling:PutScalingPolicy`, `athena:UntagResource`
+
+=== "Storage (S3 / EFS / ECR / Backup)"
+
+    Apply lifecycle policies; clean up idle buckets, objects, file systems, and
+    repositories; back up before deletion; maintain tags.
+
+    `s3:PutBucketTagging`, `s3:PutLifecycleConfiguration`, `s3:DeleteObject`,
+    `s3:DeleteBucket`, `elasticfilesystem:PutLifecycleConfiguration`,
+    `elasticfilesystem:DeleteMountTarget`, `elasticfilesystem:DeleteFileSystem`,
+    `elasticfilesystem:TagResource`, `elasticfilesystem:UntagResource`,
+    `ecr:PutLifecyclePolicy`, `ecr:DeleteRepository`, `ecr:TagResource`,
+    `ecr:UntagResource`, `backup:StartBackupJob`
+
+=== "Load balancing / observability / SSM"
+
+    Remove idle load balancers and alarms; export and trim log data; set log
+    retention; run SSM automation runbooks.
+
+    `elasticloadbalancing:DeleteLoadBalancer`, `elasticloadbalancing:AddTags`,
+    `elasticloadbalancing:RemoveTags`, `cloudwatch:DeleteAlarms`,
+    `logs:CreateExportTask`, `logs:DeleteLogStream`, `logs:PutRetentionPolicy`,
+    `ssm:StartAutomationExecution`, `ssm:GetAutomationExecution`
+
+=== "Cross-service tagging"
+
+    Apply or remove tags on any supported resource in a single call.
+
+    `tag:TagResources`, `tag:UntagResources`
+
+---
+
+## Tiers by feature
+
+Grant grows with the features you enable. Each tier includes the ones above it.
+
+| Features enabled | Grant | Access |
+|------------------|-------|--------|
+| **Billing-only** | Billing / Cost | Read-only |
+| **Billing-only + Recommendations** | + Inventory + Metrics | Read-only |
+| **Billing-only + Recommendations + Automation** | + the remediation groups you enable | Write |
+
+**Org / Account discovery** (`organizations:List*`) is separate — add it in the
+management account for whole-org, multi-account onboarding.
+
+---
+
+## Grant permission for only one service
+
+Keep the read blocks you want, then keep only the remediation groups whose actions
+you enable. For example, **EC2 rightsizing / idle cleanup only**: keep the
+inventory read (`ec2:Describe*`), the metric reads, and the **Compute** remediation
+group; delete the Network, Database, Serverless, Storage, and Ops remediation
+statements in `main.tf`. If you never run destructive actions, drop the whole
+remediation section and use the read-only role.
+
+Example — EC2 only, read side:
+
+```hcl
+# InventoryRead statement, EC2 only:
+Action = [
+  "ec2:Describe*",
+  "cloudwatch:ListMetrics",
+  "cloudwatch:GetMetricData",     # namespace AWS/EC2
+  "tag:GetResources"
+]
+```
+
+For **RDS only**, swap `ec2:Describe*` for `rds:Describe*` (metrics namespace
+`AWS/RDS`), and so on.
+
+---
+
+## Services CloudPi acts on
+
+**Compute:** EC2, AMI, Lambda
+**Storage:** EBS, Snapshot, S3, EFS, ECR
+**Database:** RDS, Aurora, DynamoDB, DAX, Redshift
+**Network:** VPC, VPC Endpoint, ENI, Elastic IP, NAT Gateway, Transit Gateway (+attachment), VPN, Load Balancer
+**Other:** CloudFront, CloudWatch, CloudWatch Logs, Athena, AWS Backup, SSM Automation
+
+---
+
+## Output & notes
+
+`role_arn` (+ `external_id`) is the preferred credential. `access_key_id` and
+`secret_access_key` are also created for direct-key access — ignore them if you use
+the role.
+
+- Prefer `role_arn` + `external_id`. The IAM user and keys are long-lived — remove
+  that block in `main.tf` if you don't need them.
+- Narrow the policy freely. CloudPi degrades gracefully and reports the specific
+  missing permission for each collection type or action.
+
+Next: [Connect AWS](ConnectAWS.md) · [Cloud Onboarding](CloudOnboarding.md)

--- a/docs/AzurePermissions.md
+++ b/docs/AzurePermissions.md
@@ -1,0 +1,192 @@
+# Azure Permissions
+
+CloudPi connects to Azure through a **Microsoft Entra application + service
+principal** assigned roles at the tenant (or a narrower) scope. This page lists the
+roles CloudPi needs, grouped by the onboarding feature they power.
+
+Grant only the roles for the features you enable during onboarding:
+
+| Feature | Roles | Access type |
+|---------|-------|-------------|
+| **Billing-only** | Billing / Cost | Read-only |
+| **Recommendations** | Inventory + Metrics | Read-only |
+| **Automation** | Contributor roles (remediation) | Write |
+
+- **Read-Only role** = Billing-only + Recommendations (collection only).
+- **Write / Remediation role** = the read-only roles plus **Automation**, the roles
+  CloudPi uses to act on approved remediations (start/stop/resize/delete and tagging).
+
+!!! note "Prerequisites"
+    - Terraform >= 1.0.
+    - An identity with **Application Administrator** (to create app registrations) and **User Access Administrator** (to assign roles at the chosen scope).
+    - Access to the **Tenant Root Management Group** (for tenant-wide scope).
+    - Your **Billing Account ID** (Azure Portal: **Cost Management + Billing → Properties**).
+
+!!! tip "Setup"
+    ```bash
+    cp terraform.tfvars.example terraform.tfvars
+    # set auth_tenant_id / auth_client_id / auth_client_secret / auth_subscription_id
+    # and billing_account_id
+    terraform init
+    terraform apply
+    terraform output -raw azure_credentials_json > cloudpi-azure.json
+    ```
+    Feed `cloudpi-azure.json` to CloudPi onboarding.
+
+Roles are assigned at the **Tenant Root Management Group** by default. Change
+`scope` to a single subscription (`/subscriptions/<sub-id>`) or resource group to
+narrow the blast radius.
+
+---
+
+## Read-Only role (Billing-only + Recommendations)
+
+All roles below are read-only. Grant the groups for the features you enable.
+
+### Billing / Cost — *Billing-only feature*
+
+Required for cost data and invoices.
+
+| Role | Used for |
+|------|----------|
+| **Storage Blob Data Reader** (on the export container) | Reading your **actual cost/usage** — Cost Management exports (FOCUS 1.0 / Actual Cost) downloaded from Blob Storage |
+| **Billing Account Reader** (Invoice API) | Invoice and monthly summary |
+
+!!! info
+    The module also assigns Storage Blob Data Reader at each subscription for
+    faster propagation. Minimum for cost = **Storage Blob Data Reader on the export
+    container** (plus Billing Account Reader for invoices).
+
+### Inventory — *Recommendations feature*
+
+Required to list resources for rightsizing.
+
+| Role | Used for |
+|------|----------|
+| **Reader** | Read metadata (`*/read`) for **every** supported resource type across the scope |
+
+Azure's built-in **Reader** is all-or-nothing across resource types — one role
+covers all inventory. To limit to one service, use a custom role (see below).
+
+### Metrics — *Recommendations feature*
+
+Required for utilization-based recommendations.
+
+| Role | Used for |
+|------|----------|
+| **Monitoring Reader** (`Microsoft.Insights/metrics/read`) | CPU / memory / network / disk and service metrics from Azure Monitor |
+
+Metrics are collected for: VM, VMSS, Storage Account, SQL Database, Cosmos DB,
+App Service Plan, Redis, Public IP, Load Balancer, NAT Gateway.
+
+### Tenant / Org discovery *(optional)*
+
+| Role | Used for |
+|------|----------|
+| **Management Group Reader** | List management groups for multi-subscription onboarding |
+
+---
+
+## Write / Remediation role (Automation)
+
+The Write role is the Read-Only role above **plus** the built-in Contributor roles
+below, which power the **Automation** feature. CloudPi uses these **only after a
+recommendation is approved** through your workflow rules. Grant only the roles for
+services whose remediations you enable.
+
+| Role | Used for |
+|------|----------|
+| **Virtual Machine Contributor** | Start, stop/deallocate, resize, and delete VMs; delete and snapshot disks; VM auto-shutdown (`Microsoft.Compute/virtualMachines/*`, `.../disks/*`) |
+| **SQL DB Contributor** | Resize/downgrade vCore and DTU tiers, auto-pause, retention, firewall rules, delete database (`Microsoft.Sql/servers/databases/*`) |
+| **Network Contributor** | Delete idle Public IPs, Load Balancers, NAT Gateways, and Private Endpoints; disable/adjust Flow Logs (`Microsoft.Network/*`) |
+| **Tag Contributor** | Attach, modify, and remove resource tags for governance (`Microsoft.Resources/tags/*`) |
+| **DocumentDB Account Contributor** | Adjust Cosmos DB throughput; delete accounts (`Microsoft.DocumentDB/databaseAccounts/*`) |
+| **Redis Cache Contributor** | Change Redis Cache SKU / scale (`Microsoft.Cache/redis/*`) |
+| **Storage Account Contributor** | Change Storage Account redundancy / SKU (`Microsoft.Storage/storageAccounts/*`) |
+| **Website Contributor** | Update or delete App Service Plans (`Microsoft.Web/serverfarms/*`) |
+| **Key Vault Contributor** | Configure Key Vault diagnostic settings (`Microsoft.KeyVault/vaults/*`) |
+| **Automation Contributor** | Run Automation runbook remediations (`Microsoft.Automation/automationAccounts/*`) |
+
+!!! note "Billing Account Reader"
+    Billing Account Reader is assigned through the Azure Billing Role Assignments
+    API (via the `azapi` provider) because billing account scope is not part of
+    standard ARM RBAC.
+
+---
+
+## Narrow the scope
+
+To limit remediation to part of the tenant, set `scope` on the write role
+assignments in `main.tf` to a single subscription (`/subscriptions/<sub-id>`) or a
+resource group ID instead of the Tenant Root Management Group. Read roles can be
+narrowed the same way.
+
+### Custom role for a single service
+
+Because **Reader** can't be filtered by resource type, use a custom role to limit
+read access to one service — for example, **VMs only**:
+
+```hcl
+resource "azurerm_role_definition" "cloudpi_vm_only" {
+  name  = "CloudPi-VM-ReadOnly"
+  scope = "/subscriptions/<sub-id>"
+  permissions {
+    actions = [
+      "Microsoft.Compute/virtualMachines/read",
+      "Microsoft.Compute/virtualMachines/*/read",
+      "Microsoft.Insights/metrics/read"          # VM metrics
+    ]
+    not_actions = []
+  }
+  assignable_scopes = ["/subscriptions/<sub-id>"]
+}
+```
+
+Assign that instead of Reader / Monitoring Reader. Swap the provider actions for
+another service (for example `Microsoft.Sql/servers/databases/read` for SQL).
+
+---
+
+## Tiers by feature
+
+Grant grows with the features you enable. Each tier includes the ones above it.
+
+| Features enabled | Grant | Access |
+|------------------|-------|--------|
+| **Billing-only** | Storage Blob Data Reader (export container) + Billing Account Reader | Read-only |
+| **Billing-only + Recommendations** | + Reader + Monitoring Reader | Read-only |
+| **Billing-only + Recommendations + Automation** | + the Contributor roles you enable | Write |
+
+**Management Group Reader** is separate — add it (at the Tenant Root MG) for
+whole-tenant, multi-subscription onboarding.
+
+---
+
+## Services CloudPi acts on
+
+**Compute:** VM, VMSS, Disk, Snapshot
+**Storage:** Storage Account, File-Share Snapshot
+**Database:** SQL Database, Cosmos DB (DB + Container), Redis
+**Web:** App Service, App Service Plan
+**Security:** Key Vault
+**Automation:** Automation runbooks
+**Network:** VNet, Public IP, Load Balancer, NAT Gateway, Private Endpoint, Flow Logs, Network Watcher
+**Governance:** Resource tags (all resource types)
+
+---
+
+## Output & notes
+
+`application_id` (client ID), `client_secret`, `tenant_id`, and
+`azure_credentials_json` — feed the JSON to CloudPi onboarding.
+
+- The Tenant Root management group is looked up by display name **"Tenant Root
+  Group"**; if yours was renamed, update `main.tf`.
+- The client secret rotates per `credential_expiry_days` (default 365).
+- The built-in Contributor roles are Azure's scoped remediation roles; they are
+  intentionally not narrowed further so CloudPi can perform every supported action
+  on the listed services.
+- If you withhold a role, CloudPi reports the exact missing permission for each
+  collection type or action it can't run.
+
+Next: [Connect Azure](ConnectAzure.md) · [Cloud Onboarding](CloudOnboarding.md)

--- a/docs/ConnectAWS.md
+++ b/docs/ConnectAWS.md
@@ -33,6 +33,9 @@ Connect AWS to CloudPi to ingest Cost and Usage Report (CUR) data and enable det
 2. Use the **External ID** provided by CloudPi.
 3. Apply least-privilege permissions required for CUR access.
 
+For the exact permissions to grant — read-only and write/remediation — see
+[AWS Permissions](AWSPermissions.md).
+
 ## Step 4 - Grant CloudPi Access to the CUR Bucket
 1. Update the S3 bucket policy to allow the CloudPi role to read CUR files.
 2. Ensure the role has permission to list and read report objects.

--- a/docs/ConnectAzure.md
+++ b/docs/ConnectAzure.md
@@ -24,6 +24,9 @@ Connect Azure to CloudPi to ingest cost exports and enable detailed billing anal
 ## Step 2 - Grant Reader Permissions
 Assign the **Reader** role to the service principal at the billing scope or subscription scope required for the export.
 
+For the full set of roles to assign — read-only and write/remediation — see
+[Azure Permissions](AzurePermissions.md).
+
 ## Step 3 - Create the Billing Export
 1. Open **Cost Management > Exports**.
 2. Create a new export to a storage account.

--- a/docs/ConnectGCP.md
+++ b/docs/ConnectGCP.md
@@ -44,6 +44,9 @@ Grant the CloudPi service account **BigQuery Data Viewer** on the billing datase
 ## Step 4 - Optional: Active Resource Access
 If you want active resource visibility, grant the **Viewer** role on the relevant projects.
 
+For the full set of roles to assign — read-only and write/remediation — see
+[GCP Permissions](GCPPermissions.md).
+
 ## Step 5 - Connect in CloudPi
 1. Go to **Integrations** or **Cloud Onboarding**.
 2. Select **GCP** and enter:

--- a/docs/GCPPermissions.md
+++ b/docs/GCPPermissions.md
@@ -1,0 +1,163 @@
+# GCP Permissions
+
+CloudPi connects to Google Cloud through a **service account** (JSON key) granted
+org-level roles. This page lists the roles CloudPi needs, grouped by the onboarding
+feature they power.
+
+Grant only the roles for the features you enable during onboarding:
+
+| Feature | Roles | Access type |
+|---------|-------|-------------|
+| **Billing-only** | Billing / Cost (BigQuery) | Read-only |
+| **Recommendations** | Inventory + Metrics | Read-only |
+| **Automation** | `write_roles` (remediation) | Write |
+
+- **Read-Only role** = Billing-only + Recommendations (collection only).
+- **Write / Remediation role** = the read-only roles plus **Automation**, the roles
+  CloudPi uses to stop, delete, resize, and label Compute Engine, networking, and
+  Cloud SQL resources.
+
+Roles live in `variables.tf` (`read_roles`, `write_roles`).
+
+!!! note "Prerequisites"
+    - Terraform >= 1.0 and org-level IAM permission to grant roles.
+    - If you are not using Cloud Shell / ADC, an admin service account JSON.
+
+!!! tip "Setup"
+    ```bash
+    cp terraform.tfvars.example terraform.tfvars
+    # set organization_id and service_account_project_id
+    terraform init
+    terraform apply
+    terraform output -raw service_account_private_key > cloudpi-gcp.json
+    ```
+    Provide the JSON key to CloudPi onboarding.
+
+Roles are granted at the **organization** by default. To grant at a single
+**project** instead, change `google_organization_iam_member` to
+`google_project_iam_member` in `main.tf`.
+
+---
+
+## Read-Only role (Billing-only + Recommendations)
+
+All roles below are read-only. Grant the groups for the features you enable.
+
+### Billing / Cost — *Billing-only feature*
+
+Required for cost data.
+
+| Role | Used for |
+|------|----------|
+| `roles/bigquery.dataViewer` | Read the billing export table data (`bigquery.tables.getData`) |
+| `roles/bigquery.jobUser` | **Run** the BigQuery query (`bigquery.jobs.create`) |
+
+!!! info "Both BigQuery roles are required"
+    `dataViewer` lets CloudPi read the billing export table; `jobUser` lets it run
+    the query against that table. Read access alone can't run a query.
+
+### Inventory — *Recommendations feature*
+
+Required to list resources for rightsizing.
+
+| Role | Covers these services |
+|------|-----------------------|
+| `roles/compute.viewer` | Compute Engine, Disk, Snapshot, Image, Machine Image, External IP, VPC, Firewall, NAT Gateway, Load Balancer |
+
+### Metrics — *Recommendations feature*
+
+Required for utilization-based recommendations.
+
+| Role | Used for |
+|------|----------|
+| `roles/monitoring.viewer` (`monitoring.timeSeries.list`) | CPU / network / disk and service metrics from Cloud Monitoring |
+
+Metrics are collected for: Compute Engine instances.
+
+### Org discovery *(optional)*
+
+| Role | Used for |
+|------|----------|
+| `roles/resourcemanager.organizationViewer` | Org node read for onboarding |
+
+For full org → folder → project traversal you also need folder/project list
+(`roles/browser` at the org). Skip for single-project onboarding.
+
+---
+
+## Write / Remediation role (Automation)
+
+The Write role is the Read-Only role above **plus** the roles below, which power the
+**Automation** feature. CloudPi uses these **only after a recommendation is
+approved** through your workflow rules.
+
+| Role | CloudPi uses it to |
+|------|--------------------|
+| `roles/compute.instanceAdmin.v1` | Stop, delete, resize, and label Compute Engine instances; delete disks and snapshots; create disk snapshots and machine images; delete/label images; label disks and snapshots; apply quarantine network tags |
+| `roles/compute.networkAdmin` | Delete firewall rules; release and label external IP addresses |
+| `roles/cloudsql.admin` | Stop, delete, and label Cloud SQL instances |
+| `roles/storage.admin` | Update Cloud Storage bucket lifecycle rules and labels |
+| `roles/cloudfunctions.admin` | Delete and label Cloud Functions |
+
+To run collection only, remove `write_roles` from the concatenation in `main.tf`
+or set `write_roles = []` in `terraform.tfvars`.
+
+---
+
+## Tiers by feature
+
+Grant grows with the features you enable. Each tier includes the ones above it.
+
+| Features enabled | Grant | Access |
+|------------------|-------|--------|
+| **Billing-only** | `bigquery.dataViewer` + `bigquery.jobUser` | Read-only |
+| **Billing-only + Recommendations** | + `compute.viewer` + `monitoring.viewer` | Read-only |
+| **Billing-only + Recommendations + Automation** | + `write_roles` | Write |
+
+**Org discovery** (`resourcemanager.organizationViewer`) is separate — add it for
+multi-project, org-wide onboarding.
+
+---
+
+## Grant permission for only one service
+
+Edit `read_roles` in `variables.tf` and keep only the role(s) for that service.
+
+| Service | Role(s) to keep |
+|---------|-----------------|
+| **Compute Engine** (+ disk/snapshot/image/network) | `roles/compute.viewer` (+ `roles/monitoring.viewer` for metrics) |
+| **Billing only** | `roles/bigquery.dataViewer` + `roles/bigquery.jobUser` |
+
+Example — Compute only:
+
+```hcl
+read_roles = [
+  "roles/compute.viewer",
+  "roles/monitoring.viewer"
+]
+```
+
+---
+
+## Services CloudPi acts on
+
+**Compute:** Compute Engine (start/stop/resize/label/quarantine, machine images)
+**Storage (block):** Persistent Disk, Snapshot, Image (delete/snapshot/label)
+**Network:** Firewall rules, External IP (delete/release/label)
+**Database:** Cloud SQL (stop/delete/label)
+**Storage (object):** Cloud Storage buckets (lifecycle/label)
+**Serverless:** Cloud Functions (delete/label)
+
+---
+
+## Output & notes
+
+`service_account_email` and `service_account_private_key` (JSON key) — feed the JSON
+to CloudPi onboarding.
+
+- Read roles are edited in `variables.tf` under `read_roles`; remediation roles
+  under `write_roles`.
+- The default `read_roles` grants only the roles CloudPi actually uses — one per
+  capability (cost, inventory, metrics, onboarding).
+
+Next: [Connect GCP](ConnectGCP.md) · [Cloud Onboarding](CloudOnboarding.md)

--- a/docs/RolesPermissions.md
+++ b/docs/RolesPermissions.md
@@ -1,0 +1,73 @@
+# Roles & Permissions
+
+Before you onboard a cloud account, you grant CloudPi a role (AWS IAM role, Azure
+service principal, or GCP service account) with a defined set of permissions. This
+section documents exactly what each permission is for, so you can grant only what
+you need.
+
+---
+
+## Permissions follow the features you enable
+
+During [Cloud Onboarding](CloudOnboarding.md) you select one or more **features** —
+**Billing-only**, **Recommendations**, and **Automation**. Each feature needs a
+specific set of permissions. Grant only the permissions for the features you turn on.
+
+| Feature | What it does | Permissions it needs | Access type |
+|---------|--------------|----------------------|-------------|
+| **Billing-only** | Cost dashboards, forecast, allocation | Billing / Cost read | Read-only |
+| **Recommendations** | Rightsizing and idle-resource optimization | Inventory + Metrics read | Read-only |
+| **Automation** | Executes approved start/stop/resize/delete/tag actions | Remediation (write) | Write |
+
+**Billing-only** and **Recommendations** are read-only. **Automation** is the only
+feature that requires write permissions.
+
+!!! info "Read-Only vs. Write role"
+    The two Terraform role tiers map directly to these features:
+
+    - **Read-Only role** = Billing-only + Recommendations (collection only)
+    - **Write / Remediation role** = the read-only permissions **plus** Automation
+
+    You never grant both — the Write role already includes everything the
+    Read-Only role has.
+
+!!! warning "Automation runs only on approval"
+    Granting Automation permissions does not trigger anything on its own. CloudPi
+    calls a remediation action **only** after the matching recommendation is
+    approved through your [Policies & Workflows](AutomationPolicies.md) rules.
+
+---
+
+## What each permission group is for
+
+Every role is grouped by **purpose**, and each group powers a specific feature:
+
+- **Billing / Cost** *(Billing-only feature)* — read your actual cost/usage export and forecast.
+- **Inventory** *(Recommendations feature)* — list resources for rightsizing and idle detection.
+- **Metrics** *(Recommendations feature)* — read CPU/network/disk utilization for usage-based recommendations.
+- **Remediation** *(Automation feature — write)* — execute approved start/stop/resize/delete/tag actions.
+- **Org / Account discovery** *(optional)* — auto-discover member accounts for multi-account onboarding.
+
+---
+
+## Provider guides
+
+Each page lists the permissions by purpose, a minimum-vs-full tier table, and how
+to narrow the grant to a single service.
+
+| Provider | Identity CloudPi uses | Guide |
+|----------|-----------------------|-------|
+| **AWS** | IAM role (with External ID) or IAM user | [AWS Permissions](AWSPermissions.md) |
+| **Azure** | Microsoft Entra app + service principal | [Azure Permissions](AzurePermissions.md) |
+| **GCP** | Service account (JSON key) | [GCP Permissions](GCPPermissions.md) |
+
+---
+
+## Principle: grant only what you need
+
+CloudPi **degrades gracefully**. If you withhold a permission, CloudPi reports the
+exact missing permission for the collection type or action it can't run — nothing
+else breaks. Start narrow and expand as you enable more features.
+
+For the onboarding flow that consumes these credentials, see
+[Cloud Onboarding](CloudOnboarding.md) and [Provider Connections](ProviderConnections.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,11 @@ nav:
           - Connect AWS: ConnectAWS.md
           - Connect Azure: ConnectAzure.md
           - Connect GCP: ConnectGCP.md
+      - Roles & Permissions:
+          - Overview: RolesPermissions.md
+          - AWS Permissions: AWSPermissions.md
+          - Azure Permissions: AzurePermissions.md
+          - GCP Permissions: GCPPermissions.md
   - Cost Assignment:
       - Cost Assignment: CostAssignment.md
       # - Tag Management: TagManagement.md                   # Disabled - superseded by Tag Governance


### PR DESCRIPTION
## Summary
Adds a new **Roles & Permissions** subsection under **Cloud Integration**, documenting the exact cloud IAM roles/permissions granted to CloudPi during onboarding. Content is derived from the shared AWS/Azure/GCP read-only and write role documents, framed around the onboarding features: **Billing-only / Recommendations / Automation**.

## New pages
- `RolesPermissions.md` - overview (read-only vs write, feature-to-permission mapping, tiers)
- `AWSPermissions.md` - AWS IAM role (read-only + write/remediation)
- `AzurePermissions.md` - Azure service principal roles (read-only + write/remediation)
- `GCPPermissions.md` - GCP service account roles (read-only + write/remediation)

## Other changes
- Cross-linked each Connect* page's IAM step to its permissions page
- Wired the new subsection into `mkdocs.yml` nav

## For reviewer
- Permission/role/action names are copied verbatim from the source docs; descriptions were reworded to match the docs' voice.
- The **feature -> permission mapping** (Billing-only = cost read, Recommendations = inventory + metrics, Automation = write) is derived from `CloudOnboarding.md` - please confirm it matches the product's actual feature wiring.